### PR TITLE
Add Screen object

### DIFF
--- a/src/tslumd/common.py
+++ b/src/tslumd/common.py
@@ -1,6 +1,7 @@
 import enum
+from typing import Tuple
 
-__all__ = ('TallyColor', 'TallyType', 'TallyState', 'MessageType')
+__all__ = ('TallyColor', 'TallyType', 'TallyState', 'MessageType', 'TallyKey')
 
 class TallyColor(enum.IntEnum):
     """Color enum for tally indicators"""
@@ -30,3 +31,9 @@ class MessageType(enum.Enum):
     _unset = 0
     display = 1 #: A message containing tally display information
     control = 2 #: A message containing control data
+
+TallyKey = Tuple[int, int]
+"""A tuple of (:attr:`screen_index <.Screen.index>`,
+:attr:`tally_index <.Tally.index>`) to uniquely identify a single :class:`.Tally`
+within its :class:`.Screen`
+"""

--- a/src/tslumd/common.py
+++ b/src/tslumd/common.py
@@ -1,6 +1,6 @@
 import enum
 
-__all__ = ('TallyColor', 'TallyType', 'TallyState')
+__all__ = ('TallyColor', 'TallyType', 'TallyState', 'MessageType')
 
 class TallyColor(enum.IntEnum):
     """Color enum for tally indicators"""
@@ -21,3 +21,12 @@ class TallyState(enum.IntFlag):
     OFF = 0     #: Off
     PREVIEW = 1 #: Preview
     PROGRAM = 2 #: Program
+
+class MessageType(enum.Enum):
+    """Message type
+
+    .. versionadded:: 0.0.2
+    """
+    _unset = 0
+    display = 1 #: A message containing tally display information
+    control = 2 #: A message containing control data

--- a/src/tslumd/messages.py
+++ b/src/tslumd/messages.py
@@ -246,6 +246,7 @@ class Display:
             The msg_type argument
         """
         kw = tally.to_dict()
+        del kw['id']
         if msg_type == MessageType.control:
             del kw['text']
         elif msg_type == MessageType.display:
@@ -260,6 +261,8 @@ class Display:
         oth_dict = other.to_dict()
         if isinstance(other, Display):
             return self_dict == oth_dict
+        else:
+            del oth_dict['id']
 
         del self_dict['type']
         if self.type == MessageType.control:

--- a/src/tslumd/messages.py
+++ b/src/tslumd/messages.py
@@ -5,10 +5,10 @@ import enum
 import struct
 from typing import List, Tuple, Dict
 
-from tslumd import TallyColor, Tally
+from tslumd import MessageType, TallyColor, Tally
 
 __all__ = (
-    'MessageType', 'Display', 'Message', 'ParseError', 'MessageParseError',
+    'Display', 'Message', 'ParseError', 'MessageParseError',
     'DmsgParseError', 'DmsgControlParseError',
 )
 
@@ -59,14 +59,6 @@ class Flags(enum.IntFlag):
     """Indicates the message contains ``SCONTROL`` data if set, otherwise ``DMESG``
     """
 
-class MessageType(enum.Enum):
-    """Message type
-
-    .. versionadded:: 0.0.2
-    """
-    _unset = 0
-    display = 1 #: A message containing tally display information
-    control = 2 #: A message containing control data
 
 @dataclass
 class Display:
@@ -79,18 +71,18 @@ class Display:
     brightness: int = 3 #: Display brightness (from 0 to 3)
     text: str = '' #: Text to display
     control: bytes = b''
-    """Control data (if :attr:`type` is :attr:`~MessageType.control`)
+    """Control data (if :attr:`type` is :attr:`~.MessageType.control`)
 
     .. versionadded:: 0.0.2
     """
 
     type: MessageType = MessageType.display
-    """The message type. One of :attr:`~MessageType.display` or
-    :attr:`~MessageType.control`.
+    """The message type. One of :attr:`~.MessageType.display` or
+    :attr:`~.MessageType.control`.
 
-    * For :attr:`~MessageType.display` (the default), the message contains
+    * For :attr:`~.MessageType.display` (the default), the message contains
       :attr:`text` information and the :attr:`control` field must be empty.
-    * For :attr:`~MessageType.control`, the message contains :attr:`control`
+    * For :attr:`~.MessageType.control`, the message contains :attr:`control`
       data and the :attr:`text` field must be empty
 
     .. versionadded:: 0.0.2
@@ -295,15 +287,15 @@ class Message:
     """A list of :class:`Display` instances"""
 
     scontrol: bytes = b''
-    """SCONTROL data (if :attr:`type` is :attr:`~MessageType.control`)"""
+    """SCONTROL data (if :attr:`type` is :attr:`~.MessageType.control`)"""
 
     type: MessageType = MessageType.display
-    """The message type. One of :attr:`~MessageType.display` or
-    :attr:`~MessageType.control`.
+    """The message type. One of :attr:`~.MessageType.display` or
+    :attr:`~.MessageType.control`.
 
-    * For :attr:`~MessageType.display` (the default), the contents of
+    * For :attr:`~.MessageType.display` (the default), the contents of
       :attr:`displays` are used and the :attr:`scontrol` field must be empty.
-    * For :attr:`~MessageType.control`, the :attr:`scontrol` field is used and
+    * For :attr:`~.MessageType.control`, the :attr:`scontrol` field is used and
       :attr:`displays` must be empty.
 
     .. versionadded:: 0.0.2

--- a/src/tslumd/sender.py
+++ b/src/tslumd/sender.py
@@ -123,7 +123,7 @@ class UmdSender(Dispatcher):
             return
         logger.debug('UmdSender.close()')
         self.running = False
-        await self.update_queue.put(False)
+        await self.update_queue.put((0, False))
         await self.tx_task
         self.tx_task = None
         self.transport.close()
@@ -353,6 +353,8 @@ class UmdSender(Dispatcher):
         async def get_queue_item(timeout):
             try:
                 item = await asyncio.wait_for(self.update_queue.get(), timeout)
+                if item[1] is False:
+                    return False
             except asyncio.TimeoutError:
                 item = None
             return item

--- a/src/tslumd/tallyobj.py
+++ b/src/tslumd/tallyobj.py
@@ -3,13 +3,13 @@ try:
 except ImportError: # pragma: no cover
     import logging
     logger = logging.getLogger(__name__)
-from typing import Dict, Set
+from typing import Dict, Set, Tuple, Iterable, Optional
 
 from pydispatch import Dispatcher, Property
 
-from tslumd import TallyType, TallyColor
+from tslumd import MessageType, TallyType, TallyColor, TallyKey
 
-__all__ = ('Tally',)
+__all__ = ('Tally', 'Screen')
 
 class Tally(Dispatcher):
     """A single tally object
@@ -25,7 +25,7 @@ class Tally(Dispatcher):
             as a float from ``0.0`` to ``1.0``
 
     :Events:
-        .. event:: on_update(instance: Tally, props_changed: Sequence[str])
+        .. event:: on_update(instance: Tally, props_changed: Set[str])
 
             Fired when any property changes
 
@@ -35,6 +35,11 @@ class Tally(Dispatcher):
 
     .. versionadded:: 0.0.2
         The :event:`on_control` event
+    """
+    screen: Optional['Screen']
+    """The parent :class:`Screen` this tally belongs to
+
+    .. versionadded:: 0.0.3
     """
     rh_tally = Property(TallyColor.OFF)
     txt_tally = Property(TallyColor.OFF)
@@ -46,7 +51,12 @@ class Tally(Dispatcher):
     _events_ = ['on_update', 'on_control']
     _prop_attrs = ('rh_tally', 'txt_tally', 'lh_tally', 'brightness', 'text', 'control')
     def __init__(self, index_, **kwargs):
+        self.screen = kwargs.get('screen')
         self.__index = index_
+        if self.screen is not None:
+            self.__id = (self.screen.index, self.__index)
+        else:
+            self.__id = None
         self._updating_props = False
         self.update(**kwargs)
         self.bind(**{prop:self._on_prop_changed for prop in self._prop_attrs})
@@ -56,6 +66,22 @@ class Tally(Dispatcher):
         """Index of the tally object from 0 to 65534 (``0xfffe``)
         """
         return self.__index
+
+    @property
+    def id(self) -> TallyKey:
+        """A key to uniquely identify a :class:`Tally` / :class:`Screen`
+        combination.
+
+        Tuple of (:attr:`Screen.index`, :attr:`Tally.index`)
+
+        Raises:
+            ValueError: If the :attr:`Tally.screen` is ``None``
+
+        .. versionadded:: 0.0.3
+        """
+        if self.__id is None:
+            raise ValueError(f'Cannot create id for Tally without a screen ({self!r})')
+        return self.__id
 
     @property
     def is_broadcast(self) -> bool:
@@ -79,7 +105,7 @@ class Tally(Dispatcher):
         return cls(0xffff, **kwargs)
 
     @classmethod
-    def from_display(cls, display: 'tslumd.Display') -> 'Tally':
+    def from_display(cls, display: 'tslumd.Display', **kwargs) -> 'Tally':
         """Create an instance from the given :class:`~.messages.Display` object
         """
         attrs = set(cls._prop_attrs)
@@ -87,7 +113,8 @@ class Tally(Dispatcher):
             attrs.discard('text')
         else:
             attrs.discard('control')
-        kw = {attr:getattr(display, attr) for attr in cls._prop_attrs}
+        kw = kwargs.copy()
+        kw.update({attr:getattr(display, attr) for attr in cls._prop_attrs})
         return cls(display.index, **kw)
 
     def update(self, **kwargs) -> Set[str]:
@@ -103,6 +130,10 @@ class Tally(Dispatcher):
             if attr not in kwargs:
                 continue
             val = kwargs[attr]
+            if attr == 'control' and val != b'':
+                if self.control == val:
+                    # logger.debug(f'resetting control, {val=}, {self.control=}')
+                    self.control = b''
             if getattr(self, attr) == val:
                 continue
             props_changed.add(attr)
@@ -112,6 +143,8 @@ class Tally(Dispatcher):
             if log_updated:
                 logger.debug(f'{self!r}.{attr} = {val!r}')
         self._updating_props = False
+        if 'control' in props_changed and self.control != b'':
+            self.emit('on_control', self, self.control)
         if len(props_changed):
             self.emit('on_update', self, props_changed)
         return props_changed
@@ -132,8 +165,6 @@ class Tally(Dispatcher):
         kw = {attr:getattr(display, attr) for attr in attrs}
         kw['LOG_UPDATED'] = True
         props_changed = self.update(**kw)
-        if is_control:
-            self.emit('on_control', self, display.control)
         return props_changed
 
     def to_dict(self) -> Dict:
@@ -141,6 +172,10 @@ class Tally(Dispatcher):
         """
         d = {attr:getattr(self, attr) for attr in self._prop_attrs}
         d['index'] = self.index
+        if self.screen is None:
+            d['id'] = None
+        else:
+            d['id'] = self.id
         return d
 
     # def to_display(self) -> 'tslumd.messages.Display':
@@ -153,9 +188,11 @@ class Tally(Dispatcher):
         if self._updating_props:
             return
         prop = kwargs['property']
+        if prop.name == 'control' and value != b'':
+            self.emit('on_control', self, value)
         if prop.name == 'brightness':
             self.normalized_brightness = (value + 1) / 4
-        self.emit('on_update', self, [prop.name])
+        self.emit('on_update', self, set([prop.name]))
 
     def __eq__(self, other):
         if not isinstance(other, Tally):
@@ -172,3 +209,190 @@ class Tally(Dispatcher):
 
     def __str__(self):
         return f'{self.index} - "{self.text}"'
+
+class Screen(Dispatcher):
+    """A group of :class:`Tally` displays
+
+    Properties:
+        scontrol(bytes): Any control data received for the screen
+
+    :Events:
+        .. event:: on_tally_added(tally: Tally)
+
+            Fired when a new :class:`Tally` instance is added to the screen
+
+        .. event:: on_tally_update(tally: Tally, props_changed: Set[str])
+
+            Fired when any :class:`Tally` property changes. This is a
+            retransmission of :event:`Tally.on_update`
+
+        .. event:: on_tally_control(tally: Tally, data: bytes)
+
+            Fired when control data is received for a :class:`Tally` object.
+            This is a retransmission of :event:`Tally.on_control`
+
+        .. event:: on_control(instance: Screen, data: bytes)
+
+            Fired when control data is received for the :class:`Screen` itself
+
+    .. versionadded:: 0.0.3
+
+    """
+    index: int
+    """The screen index from 0 to 65534 (``0xFFFE``)
+    """
+
+    tallies: Dict[int, Tally]
+    """Mapping of :class:`Tally` objects within the screen using their
+    :attr:`~Tally.index` as keys
+    """
+
+    scontrol = Property(b'')
+
+    _events_ = [
+        'on_tally_added', 'on_tally_update', 'on_tally_control', 'on_control',
+    ]
+    def __init__(self, index_: int):
+        self.__index = index_
+        self.tallies = {}
+        self.bind(scontrol=self._on_scontrol_prop)
+
+    @property
+    def index(self) -> int:
+        """The screen index from 0 to 65534 (``0xFFFE``)
+        """
+        return self.__index
+
+    @property
+    def is_broadcast(self) -> bool:
+        """``True`` if the screen is to be "broadcast", meaning sent to all
+        :attr:`screen indices<.messages.Message.screen>`.
+
+        (if the :attr:`index` is ``0xffff``)
+        """
+        return self.index == 0xffff
+
+    @classmethod
+    def broadcast(cls, **kwargs) -> 'Screen':
+        """Create a :attr:`broadcast <is_broadcast>` :class:`Screen`
+
+        (with :attr:`index` set to ``0xffff``)
+        """
+        return cls(0xffff, **kwargs)
+
+    def broadcast_tally(self, **kwargs) -> Tally:
+        """Create a temporary :class:`Tally` using :meth:`Tally.broadcast`
+
+        Arguments:
+            **kwargs: Keyword arguments to pass to the :class:`Tally` constructor
+
+        Note:
+            The tally object is not stored in :attr:`tallies` and no event
+            propagation (:event:`on_tally_added`, :event:`on_tally_update`,
+            :event:`on_tally_control`) is handled by the :class:`Screen`.
+        """
+        return Tally.broadcast(screen=self, **kwargs)
+
+    def add_tally(self, index_: int, **kwargs) -> Tally:
+        """Create a :class:`Tally` object and add it to :attr:`tallies`
+
+        Arguments:
+            index_: The tally :attr:`~Tally.index`
+            **kwargs: Keyword arguments passed to create the tally instance
+
+        Raises:
+            KeyError: If the given ``index_`` already exists
+        """
+        if index_ in self:
+            raise KeyError(f'Tally exists for index {index_}')
+        tally = Tally(index_, screen=self, **kwargs)
+        self._add_tally_obj(tally)
+        return tally
+
+    def get_or_create_tally(self, index_: int) -> Tally:
+        """If a :class:`Tally` object matching the given index exists, return
+        it. Otherwise create one and add it to :attr:`tallies`
+
+        This method is similar to :meth:`add_tally` and it can be used to avoid
+        exception handling. It does not however take keyword arguments and
+        is only intended for object creation.
+        """
+        if index_ in self:
+            return self[index_]
+        return self.add_tally(index_)
+
+    def _add_tally_obj(self, tally: Tally):
+        self.tallies[tally.index] = tally
+        if tally.is_broadcast:
+            tally.bind(
+                on_update=self._on_broadcast_tally_updated,
+                on_control=self._on_broadcast_tally_updated,
+            )
+        else:
+            tally.bind(
+                on_update=self._on_tally_updated,
+                on_control=self._on_tally_control,
+            )
+            self.emit('on_tally_added', tally)
+
+    def update_from_message(self, msg: 'tslumd.messages.Message'):
+        """Handle an incoming :class:`~.Message`
+        """
+        if msg.screen != self.index and not msg.broadcast:
+            return
+        if msg.type == MessageType.control:
+            self.scontrol = msg.scontrol
+        else:
+            for dmsg in msg.displays:
+                self.handle_dmsg(dmsg)
+
+    def handle_dmsg(self, dmsg: 'tslumd.messages.Display'):
+        if dmsg.is_broadcast:
+            for tally in self:
+                tally.update_from_display(dmsg)
+        else:
+            if dmsg.index not in self:
+                tally = Tally.from_display(dmsg, screen=self)
+                self._add_tally_obj(tally)
+                if dmsg.type == MessageType.control:
+                    tally.emit('on_control', tally, tally.control)
+            else:
+                tally = self[dmsg.index]
+                tally.update_from_display(dmsg)
+
+    def _on_tally_updated(self, *args, **kwargs):
+        self.emit('on_tally_update', *args, **kwargs)
+
+    def _on_tally_control(self, *args, **kwargs):
+        self.emit('on_tally_control', *args, **kwargs)
+
+    def _on_scontrol_prop(self, instance: 'Screen', value: bytes, **kwargs):
+        if not len(value):
+            return
+        self.emit('on_control', self, value)
+
+    def __getitem__(self, key: int) -> Tally:
+        return self.tallies[key]
+
+    def __contains__(self, key: int) -> bool:
+        return key in self.tallies
+
+    def keys(self) -> Iterable[int]:
+        yield from sorted((k for k in self.tallies.keys() if k != 0xffff))
+
+    def values(self) -> Iterable[Tally]:
+        for key in self.keys():
+            yield self[key]
+
+    def items(self) -> Iterable[Tuple[int, Tally]]:
+        for key in self.keys():
+            yield key, self[key]
+
+    def __iter__(self) -> Iterable[Tally]:
+        yield from self.values()
+
+    def __repr__(self):
+        return f'<{self.__class__.__name__}: {self}>'
+
+    def __str__(self):
+        return f'{self.index}'


### PR DESCRIPTION
- Add `tslumd.tallyobj.Screen` as a container for `tslumd.tallyobj.Tally` objects
- Propagate all necessary events in a `Screen` from its child `Tally` objects
- `Message` (Screen) and `Display` (Tally) processing is moved from `UmdReceiver` into `Screen`
- `UmdSender` and `UmdReceiver` then primarily focus on handling `Screen` instances and events
- Breaking changes are documented and primarily in the convenience methods of `UmdSender`
  since `Tally` objects are no longer addressable by index only, instead by (`screen_index`, `tally_index`)