### PR TITLE
Update Compatibility for recent Python/Pip versions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ package_dir=
 packages = find:
 install_requires =
     python-dispatch
+    importlib_metadata;python_version<'3.8'
 
 
 [options.packages.find]

--- a/src/tslumd/__init__.py
+++ b/src/tslumd/__init__.py
@@ -4,18 +4,27 @@ and other production display/control purposes.
 .. _UMDv5.0 Protocol: https://tslproducts.com/media/1959/tsl-umd-protocol.pdf
 .. _TSL Products: https://tslproducts.com
 """
-import pkg_resources
 
 try:
-    __version__ = pkg_resources.require('tslumd')[0].version
-except: # pragma: no cover
-    __version__ = 'unknown'
+    from importlib.metadata import version, PackageNotFoundError
+except ImportError:
+    # Python <3.8, fallback
+    from importlib_metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("tslumd")
+except PackageNotFoundError:
+    __version__ = "unknown"
+
 
 try:
     from loguru import logger
-except ImportError: # pragma: no cover
+except ImportError:  # pragma: no cover
     import logging
-    logging.basicConfig(format='%(asctime)s\t%(levelname)s\t%(message)s', level=logging.DEBUG)
+
+    logging.basicConfig(
+        format="%(asctime)s\t%(levelname)s\t%(message)s", level=logging.DEBUG
+    )
     logger = logging.getLogger(__name__)
 from .common import *
 from .tallyobj import *


### PR DESCRIPTION
- Remove use of deprecated pkg_resources module https://setuptools.pypa.io/en/latest/pkg_resources.html
- Use importlib for package version checking